### PR TITLE
Add base dependencies as flat files

### DIFF
--- a/applications/README.md
+++ b/applications/README.md
@@ -4,4 +4,8 @@ Contains Application manifests for OpenShift GitOps to manage the deployment of
 the common OpenStack components in preparation for network configuration and
 deployment of an OpenStack control plane.
 
-These Applications are intended to be applied to the GitOps environment on the Red Hat Advanced Cluster Management (RHACM) hub cluster.
+These Applications are intended to be applied to the GitOps environment on the
+Red Hat Advanced Cluster Management (RHACM) hub cluster. Ultimately this
+directory is likely deprecated, and was originally used in a proof-of-concept
+of using a hub cluster to manage an OpenShift cluster for a RHOSO deployment on
+a managed cluster.

--- a/applications/base/README.md
+++ b/applications/base/README.md
@@ -1,0 +1,6 @@
+# Base Applications
+
+These base Applications are for deployments where installation is being managed
+through a hub cluster such as Red Hat Advanced Cluster Management. These
+Applications are intended to be used as a push application to get the initial
+setup onto a managed cluster.

--- a/applications/openstack-common/README.md
+++ b/applications/openstack-common/README.md
@@ -2,6 +2,13 @@
 
 Deploy the common OpenStack components in order to deploy the OpenStack Operators.
 
+**NOTE:** Installation will be done via the [Validated
+Architecture](https://github.com/openstack-k8s-operators/architecture)
+repository, which installs the upstream OpenStack Operator CatalogSource and
+Subscription by default. If you are looking to install from the Red Hat
+Operators CatalogSource instead (production build of OpenStack Operators) then
+see [base/prerequisites](base/prerequisites)
+
 _Procedure_
 
 * Create the _openstack-common_ Application in OpenShift GitOps:

--- a/applications/prerequisites/application-prerequisites.yaml
+++ b/applications/prerequisites/application-prerequisites.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  name: openstack-prerequisites
+  namespace: openshift-gitops
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    kustomize:
+      patches:
+      - patch: |-
+          - op: add
+            path: /metadata/labels
+            value:
+              argocd.argoproj.io/managed-by: openshift-gitops
+        target:
+          kind: Namespace
+    path: base/prerequisites
+    repoURL: https://github.com/openstack-gitops/rhoso-gitops/base/prerequisites
+    targetRevision: HEAD
+  syncPolicy:
+    automated: {}
+

--- a/base/openstack-operator/kustomization.yaml
+++ b/base/openstack-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - subscribe/namespace.yaml
+  - subscribe/operatorgroup.yaml
+  - subscribe/subscription.yaml

--- a/base/openstack-operator/subscribe/namespace.yaml
+++ b/base/openstack-operator/subscribe/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openstack-operators

--- a/base/openstack-operator/subscribe/operatorgroup.yaml
+++ b/base/openstack-operator/subscribe/operatorgroup.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+items:
+- apiVersion: operators.coreos.com/v1
+  kind: OperatorGroup
+  metadata:
+    name: openstack-operators
+    namespace: openstack-operators
+  spec:
+    targetNamespaces:
+    - openstack-operators
+    upgradeStrategy: Default
+kind: List
+metadata:
+  resourceVersion: ""

--- a/base/openstack-operator/subscribe/subscription.yaml
+++ b/base/openstack-operator/subscribe/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/openstack-operator.openstack-operators: ''
+  name: openstack-operator
+  namespace: openstack-operators
+spec:
+  channel: stable-v1.0
+  installPlanApproval: Automatic
+  name: openstack-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/base/prerequisites/README.md
+++ b/base/prerequisites/README.md
@@ -1,0 +1,11 @@
+# Prerequisites
+
+Contains the prerequisite Operators that need to be installed on the OpenShift
+cluster prior to install of OpenStack Operator.
+
+The following Operators will be installed:
+
+- NMstate Operator
+- MetalLB Operator
+- Certificate Manager Operator
+- Cluster Observability Operator

--- a/base/prerequisites/cert-manager-operator/kustomization.yaml
+++ b/base/prerequisites/cert-manager-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - operatorgroup.yaml
+  - subscription.yaml

--- a/base/prerequisites/cert-manager-operator/namespace.yaml
+++ b/base/prerequisites/cert-manager-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator

--- a/base/prerequisites/cert-manager-operator/operatorgroup.yaml
+++ b/base/prerequisites/cert-manager-operator/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  targetNamespaces:
+  - cert-manager-operator

--- a/base/prerequisites/cert-manager-operator/subscription.yaml
+++ b/base/prerequisites/cert-manager-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  channel: stable-v1
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/base/prerequisites/cluster-observability-operator/kustomization.yaml
+++ b/base/prerequisites/cluster-observability-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - subscription.yaml

--- a/base/prerequisites/cluster-observability-operator/subscription.yaml
+++ b/base/prerequisites/cluster-observability-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-operators
+spec:
+  channel: development
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/base/prerequisites/kustomization.yaml
+++ b/base/prerequisites/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - nmstate-operator
+  - cert-manager-operator
+  - metallb-operator
+  - cluster-observability-operator

--- a/base/prerequisites/metallb-operator/kustomization.yaml
+++ b/base/prerequisites/metallb-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - operatorgroup.yaml
+  - subscription.yaml

--- a/base/prerequisites/metallb-operator/namespace.yaml
+++ b/base/prerequisites/metallb-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system

--- a/base/prerequisites/metallb-operator/operatorgroup.yaml
+++ b/base/prerequisites/metallb-operator/operatorgroup.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: metallb-operator
+  namespace: metallb-system

--- a/base/prerequisites/metallb-operator/subscription.yaml
+++ b/base/prerequisites/metallb-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: metallb-operator
+  namespace: metallb-system
+spec:
+  channel: stable
+  name: metallb-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/base/prerequisites/nmstate-operator/kustomization.yaml
+++ b/base/prerequisites/nmstate-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - operatorgroup.yaml
+  - subscription.yaml

--- a/base/prerequisites/nmstate-operator/namespace.yaml
+++ b/base/prerequisites/nmstate-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-nmstate

--- a/base/prerequisites/nmstate-operator/operatorgroup.yaml
+++ b/base/prerequisites/nmstate-operator/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-nmstate
+  namespace: openshift-nmstate
+spec:
+  targetNamespaces:
+  - openshift-nmstate

--- a/base/prerequisites/nmstate-operator/subscription.yaml
+++ b/base/prerequisites/nmstate-operator/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/kubernetes-nmstate-operator.openshift-nmstate: ""
+  name: kubernetes-nmstate-operator
+  namespace: openshift-nmstate
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kubernetes-nmstate-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Add the base dependencies for RHOSO with a simple GitOps Application, without the use of anything from validated architectures. Provides the prerequisite Operators which in documentation is done via the OpenShift UI normally. This is a set of optional installation manifests which could be performed by the administrator prior to running environment-specific installation with GitOps.