### PR TITLE
Correct small typo, exlude "environments" from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+environments/*

--- a/environments/README.md
+++ b/environments/README.md
@@ -1,4 +1,4 @@
-= Environments
+# Environments
 
 Environments contain the deployment information for a particular cloud
 environment. Environments should not be created here as they should be in a


### PR DESCRIPTION
To ensure no one pushes anything in that location, let's just exclude it
from git tree.
