### PR TITLE
Add MultiClusterHub to GitOps

### DIFF
--- a/base/initialize/gitops/components/annotations/kustomization.yaml
+++ b/base/initialize/gitops/components/annotations/kustomization.yaml
@@ -167,3 +167,15 @@ patches:
         value:
           argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
           argocd.argoproj.io/sync-wave: "3"
+
+# --- Advanced Cluster Manager setup
+  - target:
+      group: operator.open-cluster-management.io
+      version: v1
+      kind: MultiClusterHub
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+          argocd.argoproj.io/sync-wave: "-10"

--- a/base/initialize/gitops/enable/argocd-openshift-gitops.yaml
+++ b/base/initialize/gitops/enable/argocd-openshift-gitops.yaml
@@ -299,6 +299,24 @@ spec:
       return hs
     group: secrets.hashicorp.com
     kind: VaultAuth
+  - check: |
+      hs = {}
+      if obj.status ~= nil then
+        if obj.status.conditions ~= nil then
+          for i, condition in ipairs(obj.status.conditions) do
+            if condition.type == "Complete" and condition.status == "True" then
+              hs.status = "Healthy"
+              hs.message = condition.message
+              return hs
+            end
+          end
+        end
+      end
+      hs.status = "Progressing"
+      hs.message = "Waiting for MultiClusterHub to be Complete."
+      return hs
+    group: operator.open-cluster-management.io
+    kind: MultiClusterHub
   server:
     autoscale:
       enabled: false


### PR DESCRIPTION
Add MultiClusterHub to the ArgoCD health checks so that MCH can be
instantiated before creating other ACM objects.
