### PR TITLE
Add kustomization for openstack namespace

### DIFF
--- a/base/cluster/managed/rhoso/kustomization.yaml
+++ b/base/cluster/managed/rhoso/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml

--- a/base/cluster/managed/rhoso/namespace.yaml
+++ b/base/cluster/managed/rhoso/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openstack
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"


### PR DESCRIPTION
Allow creation of the openstack namespace using kustomize so it can be
referenced from a GitOps application as part of a system deployment.
