### PR TITLE
metalb: Add nodeSelector to schedule speakers on worker nodes only

### DIFF
--- a/base/cluster/managed/prerequisites/metallb-operator/metallb.yaml
+++ b/base/cluster/managed/prerequisites/metallb-operator/metallb.yaml
@@ -3,3 +3,6 @@ kind: MetalLB
 metadata:
   name: metallb
   namespace: metallb-system
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""


### PR DESCRIPTION
Avoids deploying MetalLB speakers on controller nodes in OpenShift extended architectures. Controllers typically lack network isolation, so speakers running there may fail to send L2 advertisements to EDPM nodes in RHOSO environments. Restricting speakers to worker nodes ensures proper connectivity and behavior.

This configuration still works for compact OCP clusters