### PR TITLE
Add support for upgrade scenario

### DIFF
--- a/base/initialize/gitops/enable/argocd-openshift-gitops.yaml
+++ b/base/initialize/gitops/enable/argocd-openshift-gitops.yaml
@@ -100,7 +100,7 @@ spec:
         hs.message = ""
         if obj.status ~= nil then
           if obj.status.state ~= nil then
-            if obj.status.state == "AtLatestKnown" then
+            if obj.status.state == "AtLatestKnown" or obj.status.state == "UpgradePending" then
               hs.message = obj.status.state .. " - " .. obj.status.currentCSV
               hs.status = "Healthy"
             end


### PR DESCRIPTION
In order to deploy an upgradable environment, we must deploy an older
openstack-operator and related content.
This means we must create a Subscription for those older version, and
OLM will directly try to update them - creating an installPlan and
setting the status to `UpgradePending`.
