### PR TITLE
Use actual tag instead of PR branch

### DIFF
--- a/example/controlplane/kustomization.yaml
+++ b/example/controlplane/kustomization.yaml
@@ -4,9 +4,9 @@ kind: Kustomization
 
 components:
   # Remote refs (for CI/ArgoCD):
-  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=cleaning
-  - https://github.com/openstack-gitops/rhoso-gitops/components/rhoso/controlplane?ref=cleaning
-  - https://github.com/openstack-gitops/rhoso-gitops/components/rhoso/controlplane/services/watcher?ref=cleaning
+  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=v0.1.0
+  - https://github.com/openstack-gitops/rhoso-gitops/components/rhoso/controlplane?ref=v0.1.0
+  - https://github.com/openstack-gitops/rhoso-gitops/components/rhoso/controlplane/services/watcher?ref=v0.1.0
   # Local paths (for "kustomize build" testing):
   # - ../../components/argocd/annotations
   # - ../../components/rhoso/controlplane

--- a/example/dataplane/kustomization.yaml
+++ b/example/dataplane/kustomization.yaml
@@ -4,8 +4,8 @@ kind: Kustomization
 
 components:
   # Remote refs (for CI/ArgoCD):
-  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=cleaning
-  - https://github.com/openstack-gitops/rhoso-gitops/components/rhoso/dataplane?ref=cleaning
+  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=v0.1.0
+  - https://github.com/openstack-gitops/rhoso-gitops/components/rhoso/dataplane?ref=v0.1.0
   # Local paths (for "kustomize build" testing):
   # - ../../components/argocd/annotations
   # - ../../components/rhoso/dataplane

--- a/example/dependencies/kustomization.yaml
+++ b/example/dependencies/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 
 components:
   - https://github.com/openstack-k8s-operators/architecture/lib/olm-deps?ref=7da5f2e1dc2bfce99e269b0017783679ca405d8c
-  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=cleaning
+  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=v0.1.0


### PR DESCRIPTION
Examples are now showing an actual tag instead of the PR branch, making them more usable as-is.