### PR TITLE
Add ArgoCD postDelete hooks and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ We’re using sync-waves annotations for specific jobs and actions.
 
 The range -20;20 is reserved.
 
+### PostDelete hooks
+
+PostDelete hooks run cleanup Jobs when ArgoCD Applications are deleted (e.g., orphaned
+PVCs, Vault resources). See [ArgoCD postDelete hooks](#argocd-postdelete-hooks)
+in Consume proposed components for available components and usage.
+
 ### Healthchecks
 
 TBD
@@ -181,6 +187,50 @@ These annotations enable ArgoCD to determine the order that resources are create
       - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=TAG
     # [...]
     ```
+
+### ArgoCD postDelete hooks
+
+PostDelete hooks run Jobs after an ArgoCD Application is deleted. They perform
+cleanup that would otherwise not happen automatically when resources are removed,
+such as orphaned PersistentVolumeClaims, Vault-related resources, or
+operator-specific CRs. [Learn more about ArgoCD resource hooks](https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/).
+
+**Available components**
+
+| Component | Purpose |
+|-----------|---------|
+| `components/argocd/hooks/postDelete/controlplane` | Waits for pods to terminate in `openstack` namespace, then deletes PVCs, VaultStaticSecrets, VaultAuth, VaultConnection, and Secrets |
+| `components/argocd/hooks/postDelete/dataplane` | Deletes all `OpenStackDataPlaneService` resources before namespace cleanup |
+| `components/argocd/hooks/postDelete/deploy-operators` | Deletes `cluster-observability-operator` ClusterServiceVersion (CSV) resources |
+
+**Example usage**
+
+Include the relevant postDelete component(s) in your Application or overlay, alongside
+the annotations component:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+# [...]
+spec:
+  source:
+    # [...]
+    kustomize:
+      components:
+        - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=TAG
+        - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/hooks/postDelete/controlplane?ref=TAG
+```
+
+From within an overlay or base kustomization:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=TAG
+  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/hooks/postDelete/controlplane?ref=TAG
+  # [...]
+```
 
 ## External resources
 

--- a/components/argocd/hooks/postDelete/controlplane/controlplaneCleaning.yaml
+++ b/components/argocd/hooks/postDelete/controlplane/controlplaneCleaning.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ctlplane
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+
+spec:
+  template:
+    spec:
+      serviceAccountName: openshift-gitops-argocd-application-controller
+      restartPolicy: Never
+      containers:
+        - name: wait-and-clean
+          image: registry.redhat.io/openshift4/ose-cli:latest
+          command: ['sh', '-c']
+          args:
+            - |
+              NAMESPACE="openstack"
+              MAX_ATTEMPTS=70   # Number of retries
+              SLEEP_SECONDS=10  # Interval (seconds) between checks
+              attempt=1
+
+              while [ $attempt -le $MAX_ATTEMPTS ]; do
+                # Count pods in the namespace
+                pod_count=$(oc get pods -n "$NAMESPACE" --no-headers | wc -l)
+                if [ "$pod_count" -eq 0 ]; then
+                  echo "All pods have been removed from namespace $NAMESPACE."
+                  break
+                else
+                  echo "Attempt $attempt: $pod_count pods still present in $NAMESPACE."
+                  ((attempt++))
+                  sleep "$SLEEP_SECONDS"
+                fi
+              done
+              [ "$(oc get pods -n "$NAMESPACE" --no-headers | wc -l)" -eq 0 ] || exit 1
+              oc -n openstack delete PersistentVolumeClaim --all
+              oc -n openstack delete VaultStaticSecret --all
+              oc -n openstack delete VaultAuth --all
+              oc -n openstack delete VaultConnection --all
+              oc -n openstack delete Secrets --all

--- a/components/argocd/hooks/postDelete/controlplane/kustomization.yaml
+++ b/components/argocd/hooks/postDelete/controlplane/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./controlplaneCleaning.yaml

--- a/components/argocd/hooks/postDelete/dataplane/OpenStackDataPlaneService-deletion.yaml
+++ b/components/argocd/hooks/postDelete/dataplane/OpenStackDataPlaneService-deletion.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-services
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+
+spec:
+  template:
+    spec:
+      serviceAccountName: openshift-gitops-argocd-application-controller
+      restartPolicy: Never
+      containers:
+        - name: dataplane-services
+          image: registry.redhat.io/openshift4/ose-cli:latest
+          command: ['sh', '-c']
+          args:
+            - |
+              oc -n openstack delete OpenStackDataPlaneService --all

--- a/components/argocd/hooks/postDelete/dataplane/kustomization.yaml
+++ b/components/argocd/hooks/postDelete/dataplane/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./OpenStackDataPlaneService-deletion.yaml

--- a/components/argocd/hooks/postDelete/deploy-operators/kustomization.yaml
+++ b/components/argocd/hooks/postDelete/deploy-operators/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./observability-csv.yaml

--- a/components/argocd/hooks/postDelete/deploy-operators/observability-csv.yaml
+++ b/components/argocd/hooks/postDelete/deploy-operators/observability-csv.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: clean-observability
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+
+spec:
+  template:
+    spec:
+      serviceAccountName: openshift-gitops-argocd-application-controller
+      restartPolicy: Never
+      containers:
+        - name: clean-observability-csv
+          image: registry.redhat.io/openshift4/ose-cli:latest
+          command: ['sh', '-c']
+          args:
+            - |-
+              oc get csv -A | \
+              awk '/cluster-observability-operator/ {print $1, $2}' | \
+              sort -u | \
+              xargs --no-run-if-empty -n2 sh -c 'oc -n $0 delete csv $1'


### PR DESCRIPTION
- Add postDelete hook components for controlplane, dataplane, and deploy-operators
- Document hooks in README with usage examples and component table
- Add PostDelete hooks section to ArgoCD orchestration principles

README edition involved AI assistance.

--
AI-Tool: Cursor
AI-Agent: Composer
AI-Mode: Agent

Made-with: Cursor