### PR TITLE
Update repo references from rhoso-gitops to openstack-k8s-operators/g…

### DIFF
--- a/.github/scripts/verify-kustomize-builds.py
+++ b/.github/scripts/verify-kustomize-builds.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify that all rhoso-gitops components build successfully with kustomize.
+"""Verify that all gitops components build successfully with kustomize.
 
 Discovers components dynamically under components/rhoso/ and example/,
 runs kustomize build for each, and reports a summary table. Fails only at

--- a/README.md
+++ b/README.md
@@ -171,14 +171,14 @@ These annotations enable ArgoCD to determine the order that resources are create
         path: "..."
         kustomize:
           components:
-            -  https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=TAG
+            -  https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=TAG
     ```
 1. From within an overlay or base:
     ```yaml
     apiVersion: kustomize.config.k8s.io/v1beta1
     kind: Kustomization
     components:
-      - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=TAG
+      - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=TAG
     # [...]
     ```
 

--- a/applications/vault-secrets-operator.yaml
+++ b/applications/vault-secrets-operator.yaml
@@ -15,9 +15,9 @@ spec:
   source:
     kustomize:
       components:
-        - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations
+        - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations
     path: resources/vault-secrets-operator
-    repoURL: https://github.com/openstack-gitops/rhoso-gitops.git
+    repoURL: https://github.com/openstack-k8s-operators/gitops.git
     targetRevision: HEAD
   syncPolicy:
     automated: {}

--- a/example/controlplane/kustomization.yaml
+++ b/example/controlplane/kustomization.yaml
@@ -4,9 +4,9 @@ kind: Kustomization
 
 components:
   # Remote refs (for CI/ArgoCD):
-  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=v0.1.0
-  - https://github.com/openstack-gitops/rhoso-gitops/components/rhoso/controlplane?ref=v0.1.0
-  - https://github.com/openstack-gitops/rhoso-gitops/components/rhoso/controlplane/services/watcher?ref=v0.1.0
+  - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.1.0
+  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/controlplane?ref=v0.1.0
+  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/controlplane/services/watcher?ref=v0.1.0
   # Local paths (for "kustomize build" testing):
   # - ../../components/argocd/annotations
   # - ../../components/rhoso/controlplane

--- a/example/dataplane/kustomization.yaml
+++ b/example/dataplane/kustomization.yaml
@@ -4,8 +4,8 @@ kind: Kustomization
 
 components:
   # Remote refs (for CI/ArgoCD):
-  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=v0.1.0
-  - https://github.com/openstack-gitops/rhoso-gitops/components/rhoso/dataplane?ref=v0.1.0
+  - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.1.0
+  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/dataplane?ref=v0.1.0
   # Local paths (for "kustomize build" testing):
   # - ../../components/argocd/annotations
   # - ../../components/rhoso/dataplane

--- a/example/dependencies/kustomization.yaml
+++ b/example/dependencies/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 
 components:
   - https://github.com/openstack-k8s-operators/architecture/lib/olm-deps?ref=7da5f2e1dc2bfce99e269b0017783679ca405d8c
-  - https://github.com/openstack-gitops/rhoso-gitops/components/argocd/annotations?ref=v0.1.0
+  - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.1.0


### PR DESCRIPTION
…itops

Replace all GitHub URLs and doc references from the old repository location (openstack-gitops/rhoso-gitops) to the new one (openstack-k8s-operators/gitops) after the repo move.

- applications/vault-secrets-operator.yaml: component URL and repoURL
- example/*/kustomization.yaml: remote component URLs (controlplane, dataplane, dependencies)
- README.md: example snippets in documentation
- .github/scripts/verify-kustomize-builds.py: docstring

Kustomize verification script run successfully; all components and examples build.

Change implemented with AI assistance.

Tool: Cursor IDE
Model: Cursor Agent (Auto)
Mode: Agent (plan then execute); signed commit created with non-sandbox terminal for SSH agent / GPG access.

Made-with: Cursor