### PR TITLE
Add workflow permissions to file-consistency Actions workflow

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,5 +1,7 @@
 ---
 name: file-consistency
+permissions:
+  contents: read
 on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` to the `file-consistency` workflow (`.github/workflows/yamllint.yml`) so `GITHUB_TOKEN` follows least privilege and satisfies CodeQL `actions/missing-workflow-permissions`.

Addresses GitHub code scanning alert #1 for this repository.

## Test plan

- [x] CI: `file-consistency` workflow runs on this PR
- [ ] After merge, confirm code scanning alert clears on `main`

Made with [Cursor](https://cursor.com)