### PR TITLE
feat(resources): add external-secrets-operator kustomize

### DIFF
--- a/resources/external-secrets-operator/README.md
+++ b/resources/external-secrets-operator/README.md
@@ -1,0 +1,40 @@
+# External Secrets Operator
+
+Subscribe to External Secrets Operator on OpenShift via Operator Lifecycle Manager (OLM).
+
+## Layout
+
+- **`community/`** — default install: a single `Subscription` in `openshift-operators` from the **community-operators** catalog (`spec.channel: stable`). This is split into a `community` kustomization so the **`redhat/`** overlay can include it without tripping kustomize path or cycle restrictions (you cannot reference a parent directory that contains the overlay, or files outside the overlay path, from `redhat/`).
+- **`redhat/`** — overlay that includes `community`, adds Namespace `external-secrets-operator` and an `OperatorGroup`, and applies a **JSON6902** patch to the community `Subscription` so it targets the Red Hat catalog (`openshift-external-secrets-operator`, `redhat-operators`, `stable-v1`), including `metadata.name` / `metadata.namespace` and stripping `metadata.labels`. Strategic merge does not reliably change Subscription identity fields; use RFC6902 for those edits.
+
+## Choose one catalog
+
+Do **not** install both the community OperatorHub package and the Red Hat External Secrets Operator on the same cluster. If you switch from one to the other, uninstall the existing operator first (see [Red Hat documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/external-secrets-operator-for-red-hat-openshift)).
+
+## Apply
+
+**Community (default):**
+
+```shell
+oc apply -k resources/external-secrets-operator
+```
+
+**Red Hat** (requires OpenShift 4.20+ and the `redhat-operators` catalog):
+
+```shell
+oc apply -k resources/external-secrets-operator/redhat
+```
+
+## Argo CD
+
+Point `spec.source.path` at:
+
+- `resources/external-secrets-operator` for the default (community) manifest, or
+- `resources/external-secrets-operator/redhat` for the Red Hat operator.
+
+You can mirror [applications/vault-secrets-operator.yaml](https://github.com/openstack-k8s-operators/gitops/blob/main/applications/vault-secrets-operator.yaml) (sync-wave, repo URL, kustomize components) and set `path` accordingly.
+
+## Links
+
+- [External Secrets Operator for Red Hat OpenShift](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/external-secrets-operator-for-red-hat-openshift) (Red Hat)
+- [external-secrets.io](https://external-secrets.io/) (upstream)

--- a/resources/external-secrets-operator/community/kustomization.yaml
+++ b/resources/external-secrets-operator/community/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - subscription.yaml

--- a/resources/external-secrets-operator/community/subscription.yaml
+++ b/resources/external-secrets-operator/community/subscription.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/external-secrets-operator.openshift-operators: ""
+  name: external-secrets-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: external-secrets-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/resources/external-secrets-operator/kustomization.yaml
+++ b/resources/external-secrets-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - community

--- a/resources/external-secrets-operator/redhat/kustomization.yaml
+++ b/resources/external-secrets-operator/redhat/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../community
+  - namespace.yaml
+  - operatorgroup.yaml
+patches:
+  - path: patch-subscription-redhat.json
+    target:
+      kind: Subscription
+      name: external-secrets-operator
+      namespace: openshift-operators

--- a/resources/external-secrets-operator/redhat/namespace.yaml
+++ b/resources/external-secrets-operator/redhat/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets-operator

--- a/resources/external-secrets-operator/redhat/operatorgroup.yaml
+++ b/resources/external-secrets-operator/redhat/operatorgroup.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  targetNamespaces: []

--- a/resources/external-secrets-operator/redhat/patch-subscription-redhat.json
+++ b/resources/external-secrets-operator/redhat/patch-subscription-redhat.json
@@ -1,0 +1,8 @@
+[
+  {"op": "replace", "path": "/metadata/name", "value": "openshift-external-secrets-operator"},
+  {"op": "replace", "path": "/metadata/namespace", "value": "external-secrets-operator"},
+  {"op": "remove", "path": "/metadata/labels"},
+  {"op": "replace", "path": "/spec/channel", "value": "stable-v1"},
+  {"op": "replace", "path": "/spec/name", "value": "openshift-external-secrets-operator"},
+  {"op": "replace", "path": "/spec/source", "value": "redhat-operators"}
+]


### PR DESCRIPTION
## Summary

Adds `resources/external-secrets-operator/` for installing External Secrets Operator via OLM:

- **Default (community):** `community/` subscription from `community-operators` (`oc apply -k resources/external-secrets-operator`).
- **Red Hat overlay:** `redhat/` adds Namespace, OperatorGroup, and a JSON6902 patch on the shared subscription manifest to use `redhat-operators` / `stable-v1` (OCP 4.20+).

README documents apply paths, Argo CD `path`, and not mixing both operators on one cluster.

## Testing

- `kubectl kustomize resources/external-secrets-operator`
- `kubectl kustomize resources/external-secrets-operator/redhat`

Made with [Cursor](https://cursor.com)