### PR TITLE
feat(example): add openstack-operator-cr overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Creates the main OpenStack custom resource that defines the overall OpenStack de
 
 #### Key resources
 
-* **OpenStack CR:** Primary configuration object in `openstack-operators` namespace
+* **OpenStack CR:** Primary configuration object in `openstack-operators` namespace  
+* **Example overlay:** [`example/openstack-operator-cr/`](example/openstack-operator-cr/)
 
 ### openstack-networks
 

--- a/example/README.md
+++ b/example/README.md
@@ -12,7 +12,7 @@ where the overlay includes `components/argocd/annotations`).
 | Directory | Role |
 | --------- | ---- |
 | [openstack-operator](./openstack-operator/) | Foundational OpenStack operators: CDN catalog + pinned CSV, OLM subscription from `architecture` `olm-openstack-subscriptions`, InstallPlan approval Job, RBAC. |
-| [openstack-operator-cr](./openstack-operator-cr/) | Main OpenStack custom resource (placeholder until a component exists). |
+| [openstack-operator-cr](./openstack-operator-cr/) | Main `OpenStack` custom resource in `openstack-operators`. |
 | [openstack-networks](./openstack-networks/) | Underlying networks: NNCP, NAD, NetConfig, MetalLB pools / advertisements, etc. |
 | [openstack-controlplane](./openstack-controlplane/) | `OpenStackControlPlane` and optional watcher service (networking is a separate overlay). |
 | [openstack-dataplane](./openstack-dataplane/) | Data plane node set and deployment. |

--- a/example/openstack-operator-cr/README.md
+++ b/example/openstack-operator-cr/README.md
@@ -1,10 +1,23 @@
 # openstack-operator-cr
 
-Placeholder overlay for the **openstack-operator-cr** application described in the root
-`README.md` (*Application responsibilities and content*).
+Example overlay for the **openstack-operator-cr** application described in the root
+`README.md` under *Application responsibilities and content*.
 
-There is no matching component under `components/rhoso/` yet. Replace this directory's
-`kustomization.yaml` with real `components` / `resources` when a slice is added.
+This directory applies a minimal **OpenStack** custom resource in the
+`openstack-operators` namespace. It is the primary configuration object for the overall
+OpenStack deployment on the cluster (see product documentation for full `spec` options).
 
-Upstream context: main OpenStack custom resource in the `openstack-operators`
-namespace.
+## Render
+
+From this directory:
+
+```shell
+kustomize build .
+```
+
+## Layout
+
+| File | Role |
+| ---- | ---- |
+| `openstack.yaml` | `OpenStack` CR (`operator.openstack.org/v1beta1`) |
+| `kustomization.yaml` | Sets namespace and includes the CR |

--- a/example/openstack-operator-cr/kustomization.yaml
+++ b/example/openstack-operator-cr/kustomization.yaml
@@ -2,12 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources: []
+namespace: openstack-operators
 
-# No gitops component yet for this slice. See README.md.
-# Future: add components (remote refs and local paths), for example:
-# components:
-#   - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=TAG
-#   - https://github.com/openstack-k8s-operators/gitops/components/rhoso/...?ref=TAG
-# Local paths (for "kustomize build" testing):
-#   - ../../components/argocd/annotations
+resources:
+  - openstack.yaml

--- a/example/openstack-operator-cr/openstack.yaml
+++ b/example/openstack-operator-cr/openstack.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: operator.openstack.org/v1beta1
+kind: OpenStack
+metadata:
+  name: openstack
+  namespace: openstack-operators

--- a/example/openstack-operator/README.md
+++ b/example/openstack-operator/README.md
@@ -49,5 +49,5 @@ Clusters must be able to pull images from `registry.redhat.io` (pull secret / gl
 ## Related
 
 - [`components/utilities/`](../../components/utilities/) for shared helper components (including InstallPlan approval).
-- `openstack-operator-cr` example: main `OpenStack` CR (separate overlay).
+- [`openstack-operator-cr`](../openstack-operator-cr/): main `OpenStack` CR (separate overlay).
 - `example/dependencies` for other OLM-related dependencies (MetalLB, NMState, cert-manager, etc.).


### PR DESCRIPTION
Add minimal OpenStack CR and kustomization under
example/openstack-operator-cr. Update example READMEs, link from
openstack-operator, and point to the overlay from the root README.

AI-Assist: Cursor; model=auto; mode=agent; origin=cursor