### PR TITLE
Remove apparently unneeded parameters

### DIFF
--- a/components/rhoso/controlplane/controlplane/openstack-controlplane.yaml
+++ b/components/rhoso/controlplane/controlplane/openstack-controlplane.yaml
@@ -70,12 +70,10 @@ spec:
         cell0:
           cellDatabaseAccount: nova-cell0
           cellDatabaseInstance: openstack
-          cellMessageBusInstance: rabbitmq
           hasAPIAccess: true
         cell1:
           cellDatabaseAccount: nova-cell1
           cellDatabaseInstance: openstack-cell1
-          cellMessageBusInstance: rabbitmq-cell1
           noVNCProxyServiceTemplate:
             enabled: true
             networkAttachments:
@@ -302,7 +300,6 @@ spec:
           databaseInstance: openstack
           passwordSelector:
             aodhService: AodhPassword
-          rabbitMqClusterName: rabbitmq
           serviceUser: aodh
           secret: osp-secret
         heatInstance: heat


### PR DESCRIPTION
It seems cellMessageBusInstance as well as rabbitMqClusterName aren't valid, at least in those locations.
This leads to some failures within ArgoCD, where the openstack-controlplane application doesn't converge properly, showing the following persistent diff:
```
$ argocd --grpc-web app diff openshift-gitops/cifmw-demo-controlplane

===== core.openstack.org/OpenStackControlPlane openstack/openstack-control-plane ======
1187a1188
>           cellMessageBusInstance: rabbitmq
1218a1220
>           cellMessageBusInstance: rabbitmq-cell1
1533a1536
>           rabbitMqClusterName: rabbitmq
```