### PR TITLE
feat(component): add provisioning-config component with watchAllNames…

### DIFF
--- a/components/dependencies/provisioning-config/kustomization.yaml
+++ b/components/dependencies/provisioning-config/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - provisioning-config.yaml

--- a/components/dependencies/provisioning-config/provisioning-config.yaml
+++ b/components/dependencies/provisioning-config/provisioning-config.yaml
@@ -1,0 +1,10 @@
+---
+# Baremetal Metal Operator (BMO) configuration
+
+apiVersion: metal3.io/v1alpha1
+kind: Provisioning
+metadata:
+  name: provisioning-configuration
+spec:
+  # Configure BMO to watch all namespaces
+  watchAllNamespaces: true


### PR DESCRIPTION
feat(component): add provisioning-config component with watchAllNamespaces

Jira: https://redhat.atlassian.net/browse/OSPRH-29199

Add a reusable kustomize component for BMO (Baremetal Metal Operator) Provisioning configuration. The component sets watchAllNamespaces to true, allowing BMO to watch all namespaces instead of just the default.

This can be referenced from other repos via:
https://github.com/openstack-k8s-operators/gitops/components/dependencies/provisioning-config?ref=<version>