### PR TITLE
Add RBAC roles for ESO

### DIFF
--- a/components/argocd/annotations/kustomization.yaml
+++ b/components/argocd/annotations/kustomization.yaml
@@ -99,9 +99,25 @@ patches:
         value:
           argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
           argocd.argoproj.io/sync-wave: "-5"
-  # --- Wave 1: MetalLB, network policies, and Vault connection ---
+  # --- Wave 1: MetalLB, network policies, Vault connection, and ESO config ---
   - target:
       kind: MetalLB
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+          argocd.argoproj.io/sync-wave: "1"
+  - target:
+      kind: NetworkPolicy
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-wave: "1"
+  - target:
+      group: operator.openshift.io
+      kind: ExternalSecretsConfig
     patch: |-
       - op: add
         path: /metadata/annotations

--- a/components/secrets/external-secrets-operator/redhat/external-secrets-namespace.yaml
+++ b/components/secrets/external-secrets-operator/redhat/external-secrets-namespace.yaml
@@ -1,0 +1,8 @@
+---
+# Explicitly create the external-secrets namespace so the allow-vault-egress
+# NetworkPolicy (wave 1) can always find it, regardless of ESO operator timing.
+# The ESO operator will use this existing namespace when deploying its pods.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets

--- a/components/secrets/external-secrets-operator/redhat/externalsecretsconfig.yaml
+++ b/components/secrets/external-secrets-operator/redhat/externalsecretsconfig.yaml
@@ -1,0 +1,10 @@
+---
+# ExternalSecretsConfig is required by the Red Hat External Secrets Operator (RHESO)
+# to deploy the actual ESO controller pods (external-secrets, webhook, cert-controller).
+# Sync wave and SkipDryRunOnMissingResource are managed centrally via
+# components/argocd/annotations/kustomization.yaml.
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec: {}

--- a/components/secrets/external-secrets-operator/redhat/kustomization.yaml
+++ b/components/secrets/external-secrets-operator/redhat/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Component
 resources:
   - namespace.yaml
   - operatorgroup.yaml
+  - external-secrets-namespace.yaml
+  - vault-egress-netpol.yaml
+  - externalsecretsconfig.yaml
 components:
   - ../community
 patches:

--- a/components/secrets/external-secrets-operator/redhat/vault-egress-netpol.yaml
+++ b/components/secrets/external-secrets-operator/redhat/vault-egress-netpol.yaml
@@ -1,0 +1,27 @@
+---
+# Allow ESO pods to reach Vault on port 8200.
+# The RHESO operator creates a deny-all-traffic NetworkPolicy by default,
+# so egress to Vault must be explicitly permitted.
+# Replace the cidr below with your Vault server's network CIDR to restrict
+# egress to only the network segment where Vault resides.
+# The external-secrets namespace is pre-created explicitly (external-secrets-namespace.yaml)
+# to ensure this NetworkPolicy can be applied without timing issues.
+# Sync wave is managed centrally via components/argocd/annotations/kustomization.yaml.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-vault-egress
+  namespace: external-secrets
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 8200

--- a/openshift-gitops.deploy/enable/clusterrole.yaml
+++ b/openshift-gitops.deploy/enable/clusterrole.yaml
@@ -91,6 +91,27 @@ rules:
     verbs:
       - '*'
   - apiGroups:
+      - external-secrets.io
+    resources:
+      - 'externalsecrets'
+      - 'secretstores'
+      - 'clustersecretstores'
+    verbs:
+      - '*'
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - 'networkpolicies'
+    verbs:
+      - '*'
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - 'externalsecretsconfigs'
+      - 'externalsecretsmanagers'
+    verbs:
+      - '*'
+  - apiGroups:
       - operator.openstack.org
     resources:
       - 'openstacks'


### PR DESCRIPTION
feat(eso): add RBAC, NetworkPolicy, and sync-wave support for ESO

- ClusterRole rules for external-secrets.io, networking.k8s.io, operator.openshift.io
- ExternalSecretsConfig, vault-egress NetworkPolicy, and external-secrets namespace
- Sync-wave annotations centralized in argocd/annotations component
